### PR TITLE
Fixes #14

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -200,7 +200,10 @@ class MultiCursorCasePreserve {
 
         // If no lines changed, it is a selection stage
         // !selectionIsEmpty check is needed because after undo lines will be changed and selected
-        if (!selectionIsEmpty) {
+        if (
+            !selectionIsEmpty || 
+            state.selectionsData.length !== state.numberOfSelections
+        ) {
             state.selectionsData = this.initSelectionsData(args, state);
             this.categorizeSelections(state);
             state.lines = this.createLineArray(args);


### PR DESCRIPTION
# Fixes #14

## Solution
https://github.com/Cardinal90/multi-cursor-case-preserve/assets/1939521/c1e051fc-fdb4-4c30-853b-8c50b78dd0e4

## Solution Details
Force the selection stage
```js
// ./src/extension.js: L203 -> L210
...
  if (
    !selectionIsEmpty ||
+   state.selectionsData.length !== state.numberOfSelections
  ) {
    state.selectionsData = this.initSelectionsData(args, state);
    this.categorizeSelections(state);
    state.lines = this.createLineArray(args);
    // If something changed, user just typed something, so we need to recalculate ranges for replacements
    // (recalculation on every step is needed to correctly handle multiple selections in the same line)
  } else {
...
```
This change keeps the state in sync (don't worry too much about don't having a `type`, because it has an empty `text` and will be filtered afterwards).
```
{
  "selectionsData": [{
    "text": "",
    "start": { "line": 3, "character": 0 }
  }, {
    "text": "",
    "start": { "line": 4, "character": 0 }
  }],
  "numberOfSelections": 2,
  "lines": [...]
}
```

## Context
This is caused when it creates a new editor state checking the `args.selection.length` and `state.numberOfSelections` defining `selectionsData` as an empty array.

```js 
// ./src/extension.js: L193 -> L196
...
// If number of selections is different, it is a clear marker to recalculate everything
if (args.selections.length !== state.numberOfSelections) {
  state = this.createNewEditorState(args);
}
....
```
```js
// ./src/extension.js: L18 -> L26
...
createNewEditorState(args) {
  var state = {
    selectionsData: [],
    numberOfSelections: args.selections.length,
    lines: this.createLineArray(args),
  };
  this.store.set(args.textEditor, state);
  return state;
}
...
```

then it makes another check to verify if the selection is empty or not, but only for `args` keeping the state like this
```js
// ./src/extension.js: L198 -> L199
...
// Check if all selections are empty
var selectionIsEmpty = this.areSelectionsEmpty(args);
...
```
```
{
    "selectionsData": [],
    "numberOfSelections": 2,
    "lines": [...]
}
```

So, it forgets to recalculate the selections **only** when the `state.selectionsData.length` and `state.numbersOfSelections` are equal

## Alternative Solution
Instead of re-triggering the `initSelectionsData` to prepare the `state` before `this.calculateSelectionRanges`, we could add a new check for recalculating the selections.
```js
// ./src/extension.js: L210 -> L216
...
+ } else if (state.selectionsData.length === state.numberOfSelections) {
    state.selectionsData = this.calculateSelectionRanges(args, state);
    var rangesAreEqual = this.areRangesEqualLength(state.selectionsData);
    if (rangesAreEqual) {
      this.editSelections(args, state);
    }
  }
...
```
