### PR TITLE
Fixes #16

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -119,15 +119,16 @@ class MultiCursorCasePreserve {
         state.selectionsData.forEach(function(selectionData) {
             var text = args.textEditor.document.getText(selectionData.range);
             var newText = text;
+            var firstChar = text[0] || '';
             switch (selectionData.type) {
                 case 'caps':
                     newText = text.toUpperCase();
                     break;
                 case 'lower':
-                    newText = text[0].toLowerCase() + text.substring(1);
+                    newText = firstChar.toLowerCase() + text.substring(1);
                     break;
                 case 'upper':
-                    newText = text[0].toUpperCase() + text.substring(1);
+                    newText = firstChar.toUpperCase() + text.substring(1);
                     break;
             }
             if (text !== newText) {


### PR DESCRIPTION
# Fixes #16

## Solution
https://github.com/Cardinal90/multi-cursor-case-preserve/assets/1939521/3b28eb58-209e-482b-a259-7b19da0038fe

## Solution Details
Check the first character of the `text`, if it is `undefined` assign it to `''`
```js
// ./src/extension.js: L146 -> L156
...
var firstChar = text[0] || '';
switch (selectionData.type) {
  case 'caps':
    newText = text.toUpperCase();
    break;
  case 'lower':
    newText = firstChar.toLowerCase() + text.substring(1);
    break;
  case 'upper':
    newText = firstChar.toUpperCase() + text.substring(1);
    break;
}
...
```

## Context
When we delete the selection, the `range` property from `selectionsData` keeps a value like this
```js
{
  ...
  "range": [{
    "line": 1,
    "character": 0
  }, {
    "line": 1,
    "character": 0
  }]
  ...
},
```

Then, these values are used to get the selected text from the textEditor
```js
// ./src/extension.js: L143 -> L145
...
state.selectionsData.forEach(function (selectionData) {
  var text = args.textEditor.document.getText(selectionData.range);
  var newText = text;
...
```

So the problem is that this text will be an empty string `''` and when it tries to get the first character `''[0]` it fails because it return `undefined` instead of the expected `''`.
```js
// ./src/extension.js: L146 -> L156
...
switch (selectionData.type) {
  case 'caps':
    newText = text.toUpperCase();
    break;
  case 'lower':
    newText = text[0].toLowerCase() + text.substring(1); // <-- here it fails
    break;
  case 'upper':
    newText = text[0].toUpperCase() + text.substring(1); // <-- here it fails
    break;
}
...
```